### PR TITLE
Use current date for puzzle director

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,6 @@
       </div>
       <div class="header-controls">
         <button id="prevPuzzleBtn" class="ghost" title="Previous available puzzle">◀</button>
-        <input id="datePicker" type="date" aria-label="Pick puzzle date" />
         <button id="nextPuzzleBtn" class="ghost" title="Next available puzzle">▶</button>
       </div>
     </header>

--- a/script.js
+++ b/script.js
@@ -5,7 +5,6 @@
   const gridEl = document.getElementById('grid');
   const acrossListEl = document.getElementById('acrossClues');
   const downListEl = document.getElementById('downClues');
-  const datePickerEl = document.getElementById('datePicker');
   const prevBtn = document.getElementById('prevPuzzleBtn');
   const nextBtn = document.getElementById('nextPuzzleBtn');
   const toggleDirBtn = document.getElementById('toggleDirBtn');
@@ -49,16 +48,7 @@
     return `${d.getFullYear()}-${pad2(d.getMonth()+1)}-${pad2(d.getDate())}`;
   }
 
-  function getUrlDateParam() {
-    const url = new URL(window.location.href);
-    const d = url.searchParams.get('date');
-    return d && /^\d{4}-\d{2}-\d{2}$/.test(d) ? d : null;
-  }
-  function setUrlDateParam(d) {
-    const url = new URL(window.location.href);
-    url.searchParams.set('date', d);
-    history.replaceState({}, '', url.toString());
-  }
+  // Date selection removed: always use today's date on startup
 
   async function fetchJson(path) {
     const res = await fetch(path, { cache: 'no-store' });
@@ -70,11 +60,6 @@
     const idx = await fetchJson('./puzzles/index.json');
     if (!Array.isArray(idx) || idx.length === 0) throw new Error('Empty puzzles index');
     availableDates = idx.map(e => e.date).sort();
-    // set date picker bounds
-    try {
-      datePickerEl.min = availableDates[0];
-      datePickerEl.max = availableDates[availableDates.length - 1];
-    } catch {}
     return idx;
   }
 
@@ -100,8 +85,6 @@
       showToast('Failed to load puzzle');
       return;
     }
-    datePickerEl.value = resolved;
-    setUrlDateParam(resolved);
     hydrateModelFromPuzzle();
     renderAll();
     restoreProgress();
@@ -487,17 +470,13 @@
   revealPuzzleBtn.addEventListener('click', revealPuzzle);
   clearAllBtn.addEventListener('click', clearAll);
 
-  datePickerEl.addEventListener('change', () => {
-    const val = datePickerEl.value;
-    if (/^\d{4}-\d{2}-\d{2}$/.test(val)) { loadPuzzle(val); }
-  });
+  // Date picker removed
 
   // Init
   (async function init() {
     try {
       await loadIndex();
-      const urlDate = getUrlDateParam();
-      await loadPuzzle(urlDate || todayDateStr());
+      await loadPuzzle(todayDateStr());
     } catch (e) {
       console.error(e);
       showToast('Error initializing app');

--- a/styles.css
+++ b/styles.css
@@ -44,14 +44,6 @@ body {
 .brand h1 { margin: 0; font-size: 18px; font-weight: 600; letter-spacing: .4px; }
 
 .header-controls { display: flex; align-items: center; gap: 10px; }
-.header-controls input[type="date"] {
-  color-scheme: dark;
-  background: var(--panel);
-  color: var(--text);
-  border: 1px solid #1c2130;
-  border-radius: 8px;
-  padding: 8px 10px;
-}
 
 .layout {
   display: grid;


### PR DESCRIPTION
Remove date selection UI and logic to always load today's puzzle.

---
<a href="https://cursor.com/background-agent?bcId=bc-929048f6-e2da-4609-88e6-38b200fdc27b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-929048f6-e2da-4609-88e6-38b200fdc27b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

