### PR TITLE
Toggle selected cell direction

### DIFF
--- a/script.js
+++ b/script.js
@@ -252,15 +252,16 @@
   function onCellClick(cellId) {
     const cell = cells[cellId];
     if (!cell || cell.isBlock) return;
+    // If tapping the already-focused cell, toggle direction
+    if (focusedCellId === cellId) {
+      toggleDirection();
+      return;
+    }
     const startAcross = isEntryStart(cell, 'across');
     const startDown = isEntryStart(cell, 'down');
     if (startAcross || startDown) {
       if (startAcross && startDown) {
-        if (focusedCellId === cellId && direction === 'across') {
-          selectEntry(cell.numberDown, 'down');
-        } else {
-          selectEntry(cell.numberAcross, 'across');
-        }
+        selectEntry(cell.numberAcross, 'across');
       } else if (startAcross) {
         selectEntry(cell.numberAcross, 'across');
       } else {


### PR DESCRIPTION
Allow tapping an already-focused cell to toggle the current entry direction.

---
<a href="https://cursor.com/background-agent?bcId=bc-89f0d884-ce9d-4ef4-aa88-b8ccadfe9cc1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-89f0d884-ce9d-4ef4-aa88-b8ccadfe9cc1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

